### PR TITLE
Add travis tests for the examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ app/*
 *.sublime-workspace
 tmp/*
 *.hxproj
+tests/RunTravis.n
+examples/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: haxe
+
+haxe:
+  - "3.2.0"
+  - development
+
+env:
+  - TARGET=swf
+  - TARGET=as3
+  - TARGET=js
+  - TARGET=neko
+  - TARGET=cpp
+  - TARGET=cs
+  - TARGET=java
+  - TARGET=python
+
+addons:
+  apt:
+    packages:
+      - mono-devel
+      - mono-mcs
+
+install:
+  - haxelib install hxcpp > /dev/null
+  - haxelib install hxcs > /dev/null
+  - haxelib install hxjava > /dev/null
+  - haxelib list
+
+script:
+  - cd ./tests
+  - haxe RunTravis.hxml
+  - neko RunTravis.n $TARGET

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 try-haxe
 ========
 
+[![Build Status](https://travis-ci.org/clemos/try-haxe.png)](https://travis-ci.org/clemos/try-haxe)
+
 The try-haxe project is a browser-based IDE for testing Haxe code.  It provides a
 quick and easy environment for playing with the Haxe language and compiles to
 JavaScript or Flash, instantly viewable in the browser.  It also allows saving

--- a/examples/Example-20.hx
+++ b/examples/Example-20.hx
@@ -3,8 +3,8 @@ class Test {
 		draw();
 	}
 
-#if js
 	static function draw() {
+	#if js
 		var canvas = js.Browser.document.createCanvasElement();
 		canvas.width = 400;
 		canvas.height = 400;
@@ -24,9 +24,7 @@ class Test {
 			}
 			ctx.fill();
 		}
-	}
-#elseif flash
-	static function draw() {
+	#elseif flash
 		var ctx = flash.Lib.current.graphics;
 		for (part in graphic) {
 			ctx.beginFill(Std.parseInt('0x${part.color}'));
@@ -39,8 +37,8 @@ class Test {
 				}
 			}
 		}
+	#end
 	}
-#end
 
 	static var graphic = [{"color":"f68712","path":[{"x":45,"y":12},{"x":12,"y":45},{"x":45,"y":78},{"x":78,"y":45},{"x":45,"y":12}]},{"color":"fab20b","path":[{"x":2,"y":1},{"x":45,"y":12},{"x":12,"y":45},{"x":2,"y":1}]},{"color":"f89c0e","path":[{"x":2,"y":89},{"x":12,"y":45},{"x":45,"y":78},{"x":2,"y":89}]},{"color":"f47216","path":[{"x":89,"y":1},{"x":78,"y":45},{"x":45,"y":12},{"x":89,"y":1}]},{"color":"f25c19","path":[{"x":89,"y":89},{"x":45,"y":78},{"x":78,"y":45},{"x":89,"y":89}]},{"color":"fbc707","path":[{"x":45,"y":12},{"x":2,"y":1},{"x":23,"y":1},{"x":45,"y":12}]},{"color":"fbc707","path":[{"x":45,"y":12},{"x":89,"y":1},{"x":67,"y":1},{"x":45,"y":12}]},{"color":"f68712","path":[{"x":45,"y":78},{"x":89,"y":89},{"x":67,"y":89},{"x":45,"y":78}]},{"color":"f25c19","path":[{"x":45,"y":78},{"x":2,"y":89},{"x":23,"y":89},{"x":45,"y":78}]},{"color":"fff200","path":[{"x":12,"y":45},{"x":2,"y":89},{"x":2,"y":67},{"x":12,"y":45}]},{"color":"fff200","path":[{"x":12,"y":45},{"x":2,"y":1},{"x":2,"y":23},{"x":12,"y":45}]},{"color":"f1471d","path":[{"x":78,"y":45},{"x":89,"y":89},{"x":89,"y":67},{"x":78,"y":45}]},{"color":"f1471d","path":[{"x":78,"y":45},{"x":89,"y":1},{"x":89,"y":23},{"x":78,"y":45}]}];
 }

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -1,0 +1,132 @@
+package;
+
+import sys.FileSystem;
+import sys.io.File;
+using StringTools;
+
+@:enum
+abstract Target(String) from String to String
+{
+	var Swf = "swf";
+	var As3 = "as3";
+	var Js = "js";
+	var Neko = "neko";
+	var Cpp = "cpp";
+	var Cs = "cs";
+	var Java = "java";
+	var Python = "python";
+}
+
+@:enum
+abstract ExitCode(Int) from Int to Int
+{
+	var Success = 0;
+	var Failure = 1;
+
+	@:from
+	static function fromBool(b:Bool):ExitCode {
+		return b ? ExitCode.Success : ExitCode.Failure;
+	}
+
+	@:to
+	function toColor():Color {
+		return (this == ExitCode.Success) ? Color.Green : Color.Red;
+	}
+}
+
+@:enum
+abstract Color(Int)
+{
+	var None = 0;
+	var Red = 31;
+	var Green = 32;
+}
+
+class RunTravis
+{
+	public static function main():Void {
+		var target:Target = Sys.args()[0];
+		if (target == null) {
+			Sys.println("No TARGET defined. Defaulting to neko.");
+			target = Target.Neko;
+		}
+	
+		Sys.exit(getResult([
+			buildExamples(target, Sys.args().slice(1))
+		]));
+	}
+
+	static function buildExamples(target:Target, ?included:Array<String>):ExitCode {
+		Sys.println("\nBuilding examples...\n");
+		Sys.setCwd("../examples");
+
+		var examples = FileSystem.readDirectory(".").filter(function(f) {
+			return f.endsWith(".hx");
+		});
+		
+		FileSystem.createDirectory("bin");
+
+		var results = [for (example in examples) compile(example, target)];
+		var successCount = results.filter(function(e) return e == ExitCode.Success).length;
+		var totalCount = examples.length;
+		var exitCode:ExitCode = !(successCount < totalCount);
+		Sys.println("");
+		printWithColor([for (i in 0...50) "-"].join(""), exitCode);
+		printWithColor('$successCount/$totalCount examples built successfully.', exitCode);
+
+		return exitCode;
+	}
+
+	static function compile(file:String, target:Target):ExitCode {
+		var dir = "bin/" + getFileName(file);
+		FileSystem.createDirectory(dir);
+
+		// workaround for "Module [name] does not define type [name]"
+		File.copy(file, '$dir/Test.hx');
+
+		return runInDir(dir, function() {
+			return hasExpectedResult(file, target);
+		});
+	}
+
+	static function hasExpectedResult(file:String, target:Target):ExitCode {
+		var result:ExitCode = Sys.command("haxe", ["-main", "Test", '-$target', target]);
+
+		if (result == ExitCode.Failure)
+			printWithColor('Failed when building $file', Color.Red);
+		return result;
+	}
+	
+	static function getResult(results:Array<ExitCode>):ExitCode {
+		for (result in results)
+			if (result != ExitCode.Success)
+			return ExitCode.Failure;
+		return ExitCode.Success;
+	}
+
+	static function printWithColor(message:String, color:Color):Void {
+		setColor(color);
+		Sys.println(message);
+		setColor(Color.None);
+	}
+
+	static function setColor(color:Color):Void {
+		if (Sys.systemName() == "Linux") {
+			var id = (color == Color.None) ? "" : ';$color';
+			Sys.stderr().writeString("\033[0" + id + "m");
+		}
+	}
+
+	static function runInDir(dir:String, func:Void->ExitCode):ExitCode {
+		var oldCwd = Sys.getCwd();
+		Sys.setCwd(dir);
+		var result = func();
+		Sys.setCwd(oldCwd);
+		return result;
+	}
+
+	static function getFileName(file:String):String {
+		var dotIndex = file.lastIndexOf(".");
+		return file.substring(0, dotIndex);
+	}
+}

--- a/tests/RunTravis.hxml
+++ b/tests/RunTravis.hxml
@@ -1,0 +1,2 @@
+-main RunTravis
+-neko RunTravis.n


### PR DESCRIPTION
This is a simplified version of the [test runner for the Haxe Manual examples](https://github.com/HaxeFoundation/HaxeManual/blob/master/tests/RunTravis.hx).

The examples are built on all Haxe targets for both Haxe 3.2.0 and dev.