### PR TITLE
No need to instantiate a class to Try Haxe

### DIFF
--- a/console.css
+++ b/console.css
@@ -1,0 +1,42 @@
+#debug_console{
+	pointer-events:auto;
+	position:absolute;
+	left:auto;
+	top:auto;
+	bottom:auto;
+	right:auto;
+	max-height:100%;
+	width:98%;
+	background:rgba(250,250,250,.7)!important;
+	overflow:auto;
+	font-size:14px;
+}
+
+#debug_console font.log-normal {
+	color:#000!important;
+}
+
+#debug_console_messages{
+	font:11px monospace;
+	pointer-events:auto;
+}
+
+#debug_console_close_button{
+	display:none!important;
+}
+
+#debug_console_minimize_button{
+	display:none!important;
+}
+
+#debug_console_position_button{
+	display:none!important;
+}
+
+#debug_console_pause_button{
+	display:none!important;
+}
+
+#debug_console a.log-button  {
+	display:none!important;
+}

--- a/src/api/Compiler.hx
+++ b/src/api/Compiler.hx
@@ -65,7 +65,7 @@ class Compiler {
 
 		checkMacros( source );
 
-		if(!startWithKeyWords(source)){
+		if(!isScript(source)){
 			source='class Test{
  						static function main() {
  							$source
@@ -82,7 +82,7 @@ class Compiler {
 
 	}
 
-	private function startWithKeyWords(source:String):Bool{
+	private function isScript(source:String):Bool{
 		// first, ltrim the source
 		source = StringTools.ltrim(source);
 		// then check each token

--- a/src/api/Compiler.hx
+++ b/src/api/Compiler.hx
@@ -63,12 +63,12 @@ class Compiler {
 
 		var source = program.main.source;
 
-		if(source.indexOf("class")<0){
+		if(isScript(source)){
 			source='class Test{
-				static function main() {
-					$source
-				}
-			}';
+ 						static function main() {
+ 							$source
+ 						}
+ 					}';
 		}
 
 		checkMacros( source );
@@ -80,6 +80,25 @@ class Compiler {
 		File.saveContent( tmpDir + "program", haxe.Serializer.run(program));
 		program.main.source = s;
 
+	}
+
+	private function isScript(source:String):Bool{
+		var resultPackage=false;
+		var resultImport=false;
+		var resultClass=false;
+		var tab=["package", "import", "class"];
+		for(i in tab){
+			if(i=="package"){
+				resultPackage=!StringTools.startsWith(StringTools.ltrim(source), i);
+			}
+			if(i=="import"){
+				resultImport=!StringTools.startsWith(StringTools.ltrim(source), i);
+			}
+			if(i=="class"){
+				resultClass=!StringTools.startsWith(StringTools.ltrim(source), i);
+			}
+		}
+		return resultPackage&&resultImport&&resultClass;
 	}
 
 	//public function getProgram(uid:String):{p:Program, o:Program.Output} 

--- a/src/api/Compiler.hx
+++ b/src/api/Compiler.hx
@@ -364,7 +364,7 @@ class Compiler {
 				args : args,
 				errors : errors,
 				success : false,
-				message : "Build failure"+program,
+				message : "Build failure",
 				href : "",
 				embed : "",
 				source : ""

--- a/src/api/Compiler.hx
+++ b/src/api/Compiler.hx
@@ -63,15 +63,15 @@ class Compiler {
 
 		var source = program.main.source;
 
-		if(isScript(source)){
+		checkMacros( source );
+
+		if(!startWithKeyWords(source)){
 			source='class Test{
  						static function main() {
  							$source
  						}
  					}';
 		}
-
-		checkMacros( source );
 		
 		File.saveContent( mainFile , source );
 
@@ -82,23 +82,19 @@ class Compiler {
 
 	}
 
-	private function isScript(source:String):Bool{
-		var resultPackage=false;
-		var resultImport=false;
-		var resultClass=false;
-		var tab=["package", "import", "class"];
-		for(i in tab){
-			if(i=="package"){
-				resultPackage=!StringTools.startsWith(StringTools.ltrim(source), i);
-			}
-			if(i=="import"){
-				resultImport=!StringTools.startsWith(StringTools.ltrim(source), i);
-			}
-			if(i=="class"){
-				resultClass=!StringTools.startsWith(StringTools.ltrim(source), i);
-			}
+	private function startWithKeyWords(source:String):Bool{
+		// first, ltrim the source
+		source = StringTools.ltrim(source);
+		// then check each token
+		for( token in ["package","import","class"] ) {
+   			// if source starts with either token, we know it's a script, 
+   			// and thus we can return true and break the loop
+   			if(StringTools.startsWith( source, token )) {
+       			return true;
+   			}
 		}
-		return resultPackage&&resultImport&&resultClass;
+		// otherwise, we know it's not a script
+		return false;
 	}
 
 	//public function getProgram(uid:String):{p:Program, o:Program.Output} 

--- a/src/api/Compiler.hx
+++ b/src/api/Compiler.hx
@@ -36,7 +36,6 @@ class Compiler {
 	}
 
 	public function prepareProgram( program : Program ){
-
 		while( program.uid == null ){
 
 			var id = haxe.crypto.Md5.encode( Std.string( Math.random() ) +Std.string( Date.now().getTime() ) );
@@ -63,6 +62,7 @@ class Compiler {
 		mainFile = tmpDir + program.main.name + ".hx";
 
 		var source = program.main.source;
+
 		checkMacros( source );
 		
 		File.saveContent( mainFile , source );
@@ -284,7 +284,27 @@ class Compiler {
 				args.push( "-js" );
 				args.push( outputPath );
 				html.body.push("<script src='//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js'></script>");
-				html.body.push("<script src='//markknol.github.io/console-log-viewer/console-log-viewer.js'></script>");
+				html.body.push('<script>
+					ConsoleLogViewer.TOTAL = 999999;
+					var d = document.getElementById("debug_console");
+					d.style.pointerEvents = "auto";
+					d.style.position = "absolute";
+					d.style.left = "auto";
+					d.style.top = "auto";
+					d.style.bottom = "auto";
+					d.style.right = "auto";
+					d.style.maxHeight = "100%";
+					d.style.width = "98%";
+					d.style.background = "rgba(250,250,250,.7)";
+					d.style.overflow = "auto";
+					var m = document.getElementById("debug_console_messages");
+					m.style.font = "11px monospace";
+					m.style.pointerEvents = "auto";
+					document.getElementById("debug_console_close_button").style.display="none";
+					document.getElementById("debug_console_minimize_button").style.display="none";
+					document.getElementById("debug_console_position_button").style.display="none";
+					document.getElementById("debug_console_pause_button").style.display="none";
+					</script>');
 				html.body.push("<style type='text/css'>
 					#debug_console {
 						background:#fff;
@@ -344,7 +364,7 @@ class Compiler {
 				args : args,
 				errors : errors,
 				success : false,
-				message : "Build failure",
+				message : "Build failure"+program,
 				href : "",
 				embed : "",
 				source : ""

--- a/src/api/Compiler.hx
+++ b/src/api/Compiler.hx
@@ -283,41 +283,9 @@ class Compiler {
 				outputPath = tmpDir + name + ".js";
 				args.push( "-js" );
 				args.push( outputPath );
+				html.head.push("<link rel='stylesheet' href='"+Api.root+"/console.css' type='text/css'>");
 				html.body.push("<script src='//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js'></script>");
-				html.body.push('<script>
-					ConsoleLogViewer.TOTAL = 999999;
-					var d = document.getElementById("debug_console");
-					d.style.pointerEvents = "auto";
-					d.style.position = "absolute";
-					d.style.left = "auto";
-					d.style.top = "auto";
-					d.style.bottom = "auto";
-					d.style.right = "auto";
-					d.style.maxHeight = "100%";
-					d.style.width = "98%";
-					d.style.background = "rgba(250,250,250,.7)";
-					d.style.overflow = "auto";
-					var m = document.getElementById("debug_console_messages");
-					m.style.font = "11px monospace";
-					m.style.pointerEvents = "auto";
-					document.getElementById("debug_console_close_button").style.display="none";
-					document.getElementById("debug_console_minimize_button").style.display="none";
-					document.getElementById("debug_console_position_button").style.display="none";
-					document.getElementById("debug_console_pause_button").style.display="none";
-					</script>');
-				html.body.push("<style type='text/css'>
-					#debug_console {
-						background:#fff;
-						font-size:14px;
-					}
-					#debug_console font.log-normal {
-						color:#000;
-					}
-					#debug_console a.log-button  {
-						display:none;
-					}
-					</style>");
-				
+				html.body.push("<script src='//markknol.github.io/console-log-viewer/console-log-viewer.js'></script>");			
 
 			case SWF( name , version ):
 				Api.checkSanity( name );

--- a/src/api/Compiler.hx
+++ b/src/api/Compiler.hx
@@ -63,6 +63,14 @@ class Compiler {
 
 		var source = program.main.source;
 
+		if(source.indexOf("class")<0){
+			source='class Test{
+				static function main() {
+					$source
+				}
+			}';
+		}
+
 		checkMacros( source );
 		
 		File.saveContent( mainFile , source );


### PR DESCRIPTION
During my first steps in Try Haxe I waste a lot of time to undertand why something like 

`for (i in [1, 2, 3]) {
    trace(i);
}`

was not working.

Indeed, I didn't know that you have to instantiate a class to Try Haxe ;)

Now it's implicit 
