### PR TITLE
Fix a bug where the end of line is not splitted correctly

### DIFF
--- a/src/SourceTools.hx
+++ b/src/SourceTools.hx
@@ -3,7 +3,7 @@ using Lambda;
 class SourceTools {
 
 	public static function splitLines(str:String):Array<String> {
-		return ~/[\n|\r|\r\n]/g.split(str);
+		return ~/\r\n|\n|\r/g.split(str);
 	}
 
 	public static function indexToPos( src :String , idx : Int ) : { line : Int , ch : Int } {


### PR DESCRIPTION
Hello i think the regex here
https://github.com/clemos/try-haxe/blob/master/src/SourceTools.hx#L6

is invalid as it split also the line with | and the it should split the \r\n before the other one char line.

You can see it in action here:
https://try.haxe.org/#Bdb77

Patrick.