### PR TITLE
Add missing / in URL

### DIFF
--- a/examples/Example-19.hx
+++ b/examples/Example-19.hx
@@ -1,6 +1,6 @@
 class Test {
   static function main() {
-    var http = new haxe.Http("https://api.ipify.org?format=json");
+    var http = new haxe.Http("https://api.ipify.org/?format=json");
     http.onData = function(data) {
       var result:IpAddress = haxe.Json.parse(data);
       trace('Your IP-address: ${result.ip}');


### PR DESCRIPTION
Current version only works with JS target – see https://github.com/HaxeFoundation/haxe/issues/7563