### PR TITLE
Change top and bottom of console window

### DIFF
--- a/console.css
+++ b/console.css
@@ -2,8 +2,8 @@
 	pointer-events:auto;
 	position:absolute;
 	left:auto;
-	top:auto;
-	bottom:auto;
+	top:8px;
+	bottom:0;
 	right:auto;
 	max-height:100%;
 	width:98%;


### PR DESCRIPTION
This should fix #72 but was only tested by editing the values in the browser (Firefox).

By setting the values for top and bottom, the window size should remain the same as before but no text is hidden at the bottom of the console window.